### PR TITLE
Correctly call `render_capability_section` in system definition template

### DIFF
--- a/templates/20-System Analysis/system-definition.html.j2
+++ b/templates/20-System Analysis/system-definition.html.j2
@@ -54,7 +54,7 @@
 
 <h2>3 System Capabilities</h2>
 {% set capabilities = model.sa.all_capabilities %}
-{{ render_capability_section(capabilities) | safe }}
+{{ render_capability_section(object, capabilities) | safe }}
 
 <h2>4 System Boundary</h2>
 <p>


### PR DESCRIPTION
Involved capabilities of the system are not visible in the system definition anymore, because of a tiny bug. Fixed with this PR.